### PR TITLE
chore: configure clippy exported api lint

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,1 @@
+avoid-breaking-exported-api = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,9 @@ default = []
 no_std = []
 bench = []
 
-# [dev-dependencies]
-# criterion = "0.3.5"
+[dev-dependencies]
+criterion = "0.3.5"
 
-# [[bench]]
-# name = "id"
-# harness = false
+[[bench]]
+name = "id"
+harness = false

--- a/benches/id.rs
+++ b/benches/id.rs
@@ -13,31 +13,63 @@ fn bench_unicode_id(c: &mut Criterion) {
     group.bench_with_input(
         BenchmarkId::new("is_id_start", "unicode"),
         &unicode_chars,
-        |b, chars| b.iter(|| chars.iter().copied().map(UnicodeID::is_id_start).last()),
+        |b, chars| {
+            b.iter(|| {
+                chars
+                    .iter()
+                    .rev()
+                    .map(|ch| UnicodeID::is_id_start(*ch))
+                    .next()
+            })
+        },
     );
     group.throughput(Throughput::Bytes(ascii_chars.len() as u64));
     group.bench_with_input(
         BenchmarkId::new("is_id_start", "ascii"),
         &ascii_chars,
-        |b, chars| b.iter(|| chars.iter().copied().map(UnicodeID::is_id_start).last()),
+        |b, chars| {
+            b.iter(|| {
+                chars
+                    .iter()
+                    .rev()
+                    .map(|ch| UnicodeID::is_id_start(*ch))
+                    .next()
+            })
+        },
     );
     group.throughput(Throughput::Bytes(unicode_chars.len() as u64));
     group.bench_with_input(
         BenchmarkId::new("is_id_continue", "unicode"),
         &unicode_chars,
-        |b, chars| b.iter(|| chars.iter().copied().map(UnicodeID::is_id_continue).last()),
+        |b, chars| {
+            b.iter(|| {
+                chars
+                    .iter()
+                    .rev()
+                    .map(|ch| UnicodeID::is_id_continue(*ch))
+                    .next()
+            })
+        },
     );
     group.throughput(Throughput::Bytes(ascii_chars.len() as u64));
     group.bench_with_input(
         BenchmarkId::new("is_id_continue", "ascii"),
         &ascii_chars,
-        |b, chars| b.iter(|| chars.iter().copied().map(UnicodeID::is_id_continue).last()),
+        |b, chars| {
+            b.iter(|| {
+                chars
+                    .iter()
+                    .rev()
+                    .map(|ch| UnicodeID::is_id_continue(*ch))
+                    .next()
+            })
+        },
     );
     group.finish();
 }
 
 fn chars(range: std::ops::Range<u32>) -> Vec<char> {
-    range.filter_map(|i| std::char::from_u32(i)).collect()
+    range.filter_map(std::char::from_u32).collect()
 }
 
 criterion_group!(benches, bench_unicode_id);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,10 +33,9 @@
     html_favicon_url = "https://unicode-rs.github.io/unicode-rs_sm.png"
 )]
 #![no_std]
-#![cfg_attr(feature = "bench", feature(test, unicode_internals))]
+#![cfg_attr(feature = "bench", feature(test))]
 
 #[cfg(test)]
-#[macro_use]
 extern crate std;
 
 #[cfg(feature = "bench")]
@@ -51,6 +50,7 @@ mod tables;
 mod tests;
 
 /// Methods for determining if a character is a valid identifier character.
+#[allow(clippy::wrong_self_convention)]
 pub trait UnicodeID {
     /// Returns whether the specified character satisfies the 'ID_Start'
     /// Unicode property.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #[cfg(feature = "bench")]
-use std::iter;
+use std::panic;
 #[cfg(feature = "bench")]
 use std::prelude::v1::*;
 #[cfg(feature = "bench")]
@@ -21,7 +21,7 @@ use UnicodeID;
 #[cfg(feature = "bench")]
 #[bench]
 fn cargo_is_id_start(b: &mut Bencher) {
-    let string = iter::repeat('a').take(4096).collect::<String>();
+    let string = "a".repeat(4096);
 
     b.bytes = string.len() as u64;
     b.iter(|| string.chars().all(super::UnicodeID::is_id_start));
@@ -30,7 +30,7 @@ fn cargo_is_id_start(b: &mut Bencher) {
 #[cfg(feature = "bench")]
 #[bench]
 fn stdlib_is_id_start(b: &mut Bencher) {
-    let string = iter::repeat('a').take(4096).collect::<String>();
+    let string = "a".repeat(4096);
 
     b.bytes = string.len() as u64;
     b.iter(|| string.chars().all(char::is_id_start));
@@ -39,7 +39,7 @@ fn stdlib_is_id_start(b: &mut Bencher) {
 #[cfg(feature = "bench")]
 #[bench]
 fn cargo_id_continue(b: &mut Bencher) {
-    let string = iter::repeat('a').take(4096).collect::<String>();
+    let string = "a".repeat(4096);
 
     b.bytes = string.len() as u64;
     b.iter(|| string.chars().all(super::UnicodeID::is_id_continue));
@@ -48,7 +48,7 @@ fn cargo_id_continue(b: &mut Bencher) {
 #[cfg(feature = "bench")]
 #[bench]
 fn stdlib_id_continue(b: &mut Bencher) {
-    let string = iter::repeat('a').take(4096).collect::<String>();
+    let string = "a".repeat(4096);
 
     b.bytes = string.len() as u64;
     b.iter(|| string.chars().all(char::is_id_continue));

--- a/tests/exhaustive_tests.rs
+++ b/tests/exhaustive_tests.rs
@@ -5,8 +5,7 @@ use unicode_id::UnicodeID;
 /// See: http://www.unicode.org/glossary/#unicode_scalar_value
 fn all_valid_chars() -> impl Iterator<Item = char> {
     (0u32..=0xD7FF).chain(0xE000u32..=0x10FFFF).map(|u| {
-        core::convert::TryFrom::try_from(u)
-            .expect("The selected range should be infallible if the docs match impl")
+        std::char::from_u32(u).expect("The selected range should contain only valid chars")
     })
 }
 


### PR DESCRIPTION
Ensures clippy is clean with `avoid-breaking-exported-api = false`.

Validated with `cargo +nightly clippy --workspace --all-targets --all-features`.
