### PR TITLE
chore: standardize rustfmt config

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,6 @@
+style_edition = "2024"
+use_small_heuristics = "Max"
+use_field_init_shorthand = true
+reorder_modules = true
+merge_derives = true
+remove_nested_parens = true

--- a/benches/id.rs
+++ b/benches/id.rs
@@ -1,7 +1,7 @@
 extern crate criterion;
 extern crate unicode_id;
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use unicode_id::UnicodeID;
 
 fn bench_unicode_id(c: &mut Criterion) {
@@ -13,57 +13,23 @@ fn bench_unicode_id(c: &mut Criterion) {
     group.bench_with_input(
         BenchmarkId::new("is_id_start", "unicode"),
         &unicode_chars,
-        |b, chars| {
-            b.iter(|| {
-                chars
-                    .iter()
-                    .rev()
-                    .map(|ch| UnicodeID::is_id_start(*ch))
-                    .next()
-            })
-        },
+        |b, chars| b.iter(|| chars.iter().rev().map(|ch| UnicodeID::is_id_start(*ch)).next()),
     );
     group.throughput(Throughput::Bytes(ascii_chars.len() as u64));
-    group.bench_with_input(
-        BenchmarkId::new("is_id_start", "ascii"),
-        &ascii_chars,
-        |b, chars| {
-            b.iter(|| {
-                chars
-                    .iter()
-                    .rev()
-                    .map(|ch| UnicodeID::is_id_start(*ch))
-                    .next()
-            })
-        },
-    );
+    group.bench_with_input(BenchmarkId::new("is_id_start", "ascii"), &ascii_chars, |b, chars| {
+        b.iter(|| chars.iter().rev().map(|ch| UnicodeID::is_id_start(*ch)).next())
+    });
     group.throughput(Throughput::Bytes(unicode_chars.len() as u64));
     group.bench_with_input(
         BenchmarkId::new("is_id_continue", "unicode"),
         &unicode_chars,
-        |b, chars| {
-            b.iter(|| {
-                chars
-                    .iter()
-                    .rev()
-                    .map(|ch| UnicodeID::is_id_continue(*ch))
-                    .next()
-            })
-        },
+        |b, chars| b.iter(|| chars.iter().rev().map(|ch| UnicodeID::is_id_continue(*ch)).next()),
     );
     group.throughput(Throughput::Bytes(ascii_chars.len() as u64));
     group.bench_with_input(
         BenchmarkId::new("is_id_continue", "ascii"),
         &ascii_chars,
-        |b, chars| {
-            b.iter(|| {
-                chars
-                    .iter()
-                    .rev()
-                    .map(|ch| UnicodeID::is_id_continue(*ch))
-                    .next()
-            })
-        },
+        |b, chars| b.iter(|| chars.iter().rev().map(|ch| UnicodeID::is_id_continue(*ch)).next()),
     );
     group.finish();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,8 @@ extern crate std;
 #[cfg(feature = "bench")]
 extern crate test;
 
-use tables::derived_property;
 pub use tables::UNICODE_VERSION;
+use tables::derived_property;
 
 mod tables;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -65,9 +65,7 @@ fn test_is_id_start() {
 
 #[test]
 fn test_is_not_id_start() {
-    let chars = [
-        '\x00', '\x01', '0', '9', ' ', '[', '<', '{', '(', '\u{02c2}', '\u{ffff}',
-    ];
+    let chars = ['\x00', '\x01', '0', '9', ' ', '[', '<', '{', '(', '\u{02c2}', '\u{ffff}'];
 
     for ch in &chars {
         assert!(!super::UnicodeID::is_id_start(*ch), "{}", ch);
@@ -85,9 +83,7 @@ fn test_is_id_continue() {
 
 #[test]
 fn test_is_not_id_continue() {
-    let chars = [
-        '\x00', '\x01', ' ', '[', '<', '{', '(', '\u{02c2}', '\u{ffff}',
-    ];
+    let chars = ['\x00', '\x01', ' ', '[', '<', '{', '(', '\u{02c2}', '\u{ffff}'];
 
     for &ch in &chars {
         assert!(!super::UnicodeID::is_id_continue(ch), "{}", ch);


### PR DESCRIPTION
Standardizes the Rustfmt config filename and options, then applies cargo fmt.
