### PR TITLE
ci: remove old rust versions from test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable, 1.58.1, 1.17.0]
+        rust: [nightly, beta, stable]
     env:
       RUSTUP_TOOLCHAIN: ${{ matrix.rust }}
     steps:
@@ -30,4 +30,3 @@ jobs:
         # if: matrix.rust == 'nightly'
       - run: cargo build
       - run: cargo test
-        if: matrix.rust != '1.17.0'


### PR DESCRIPTION
Drop `1.58.1` and `1.17.0` from the CI matrix, leaving `nightly`/`beta`/`stable`. These jobs can no longer pass now that `Cargo.lock` is committed (#27) — it uses the v4 lockfile format, which requires cargo 1.78+. Also removes the `1.17.0` guard on `cargo test` since it's no longer reachable.